### PR TITLE
[2026-02-01] #12 StatefulWidger에서 FutureBuilder 사용하여 initState 대체하는 코드

### DIFF
--- a/json_placeholder/lib/futurebuilder_stateful.dart
+++ b/json_placeholder/lib/futurebuilder_stateful.dart
@@ -50,13 +50,13 @@ class _HttpSampleScreenState extends State<HttpSampleScreen> {
       ),
       body: Center(
         child: FutureBuilder(
-          future: getData(),
-          builder: (context, asyncSnapshot) {
-            if (asyncSnapshot.hasData) {
-              body = asyncSnapshot.data!;
+            future: getData(),
+            builder: (context, asyncSnapshot) {
+              if (asyncSnapshot.hasData) {
+                body = asyncSnapshot.data!;
+              }
+              return Text(body);
             }
-            return Text(body);
-          }
         ),
       ),
       floatingActionButton: FloatingActionButton(onPressed: () {


### PR DESCRIPTION
## 📌 관련 이슈
- Close #12 

## 📖 학습 및 변경 사항
- `initState`와 `FutureBuilder`의 차이 학습

## 🛠️ 구현 상세 (Technical Note)
- `initState` 삭제
- `FutureBuilder`을 활용하여 동일한 동작을 하게 함

## 📸 결과물 (Screenshots / GIF)
| Before | After |
| :---: | :---: |
| - | https://github.com/user-attachments/assets/0af6fd06-2a92-4cb7-a5b2-6aca27eed318 |

## ✅ 셀프 체크리스트
- [x] `flutter analyze` 명령어로 코드 상의 경고나 에러가 없는지 확인했나요?
- [x] 불필요한 주석이나 테스트용 `print` 문을 제거했나요?
- [x] 학습 목표에 명시된 기능을 모두 구현했나요?
- [x] 새로운 개념이나 코드를 이슈(Issue)에 기록했나요?
